### PR TITLE
Added parent to header for Bulk job

### DIFF
--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -109,10 +109,12 @@ case class BulkRelation(
       }
 
       val fetchAllResults = (resultId: String, batchInfoId: String) => {
+        logger.error("About to Result for ResultId: " + resultId)
+
         if(bulkAPI == null) {
           SerializableBulkAPIWrapper.initializeInstance(username, password, login, version)
         }
-        logger.error("Getting Result for ResultId: " + resultId)
+
         val result = bulkAPI.getBatchResult(jobId, batchInfoId, resultId)
 
         val splitRows = splitCsvByRows(result)

--- a/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
+++ b/src/main/scala/com/springml/spark/salesforce/DefaultSource.scala
@@ -216,6 +216,8 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
       val chunkSize = parameters.get("chunkSize")
       logger.info("createBulkRelation :: chunkSize: " + chunkSize)
 
+      val parent = parameters.get("parent")
+
       if (!chunkSize.isEmpty) {
         try {
           chunkSize.get.toInt
@@ -223,10 +225,18 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
         catch {
           case e: Exception => throw new Exception("chunkSize must be a valid integer")
         }
-        customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=${chunkSize.get}")
-//        customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=${chunkSize.get}; parent=Account")
+
+        if(parent.isEmpty) {
+          customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=${chunkSize.get}")
+        } else {
+          customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"chunkSize=${chunkSize.get}; parent=${parent.get}")
+        }
       } else {
-        customHeaders += new BasicHeader("Sforce-Enable-PKChunking", "true")
+        if(parent.isEmpty) {
+          customHeaders += new BasicHeader("Sforce-Enable-PKChunking", "true")
+        } else {
+          customHeaders += new BasicHeader("Sforce-Enable-PKChunking", s"parent=${parent.get}")
+        }
       }
     }
 


### PR DESCRIPTION
Parent object support, which allows query-distribution at SF, thus making large ingestions possible, which was lacking 